### PR TITLE
去 json

### DIFF
--- a/2023-1112/freebsd-rong-qi-jing-xiang.md
+++ b/2023-1112/freebsd-rong-qi-jing-xiang.md
@@ -38,7 +38,7 @@ fdb4ee0a131a70df2aae5c022b677c5afbacb5ec19aa24480f9b9f5e8f30fd18
 
 此捆绑包中的所有元数据文件都是 JSON 格式，如此处所描述。顶层的 `index.json` 文件通过其哈希链接到清单（manifest）：
 
-```json
+```ini
 $ cat index.json | jq
 {
   "schemaVersion": 2,
@@ -58,7 +58,7 @@ $ cat index.json | jq
 
 OCI 镜像规范还支持多架构镜像，它们只是清单的列表：
 
-```json
+```ini
 {
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",

--- a/2024-0102/sriov-yi-cheng-wei-freebsd-zhong-zhong-yao-de-gong-neng.md
+++ b/2024-0102/sriov-yi-cheng-wei-freebsd-zhong-zhong-yao-de-gong-neng.md
@@ -132,7 +132,7 @@ IOVCTL OPTIONS
 
 我们将使用参数 `mac-addr` 为每个 VF 设置特定的 MAC 地址。在此例中，把 MAC 地址设置为随意生成的，但我将演示如何在配置文件中设置 PF 参数、默认的 VF 参数以及特定于单个 VF 的参数。
 
-```json
+```ini
 PF {
        device : “ixl0”
        num_vfs : 2
@@ -319,7 +319,7 @@ vmm_load="YES"
         该参数控制是否将 VF 保留为 bhyve(8) 虚拟机的 PCI 直通设备。如果设置为 true，VF 将被保留为 PCI 直通设备，并且无法从物理机操作系统访问。此参数的默认值为 false。
 ```
 
-```json
+```ini
 PF {
         device : “ixl0”
         num_vfs : 2

--- a/2024-0506/shi-yong-ruan-jian-kai-fa-ding-zhi-ansible-mo-kuai.md
+++ b/2024-0506/shi-yong-ruan-jian-kai-fa-ding-zhi-ansible-mo-kuai.md
@@ -69,7 +69,7 @@ ansible-playbook touch.yml
 
 当文件 `/tmp/BSD.txt` 不存在时，playbook 输出如下：
 
-```json
+```ini
 PLAY [localhost] *****************************************
 
 TASK [Run our custom touch module] ***********************
@@ -87,7 +87,7 @@ ok: [localhost] => {
 
 当文件 `/tmp/BSD.txt` 存在（来自之前的运行）时，输出如下：
 
-```json
+```ini
 PLAY [localhost] *****************************************
 
 TASK [Run our custom touch module] ***********************
@@ -161,7 +161,7 @@ ansible-playbook hello.yml
 
 输出如下：
 
-```json
+```ini
 PLAY [localhost] *****************************************
 
 TASK [Testing the Python module] *************************
@@ -248,7 +248,7 @@ tasks:
 
 playbook 执行的相关输出如下：
 
-```json
+```ini
 ok: [localhost] => {
     “result”: {
         “changed”: false,
@@ -321,7 +321,7 @@ main()
 
 这将得到如下预期的输出：
 
-```json
+```ini
 TASK [Testing the calc module] **********************************************
 fatal: [localhost]: FAILED! => {“changed”: false, “msg”: “Invalid Operation”}
 ```

--- a/2024-0708/iscsi.md
+++ b/2024-0708/iscsi.md
@@ -36,7 +36,7 @@ zfs create -o volmode=dev -V 50G tank/wblock0
 
 接下来，创建一个仅允许 root 读/写的文件 `/etc/ctl.conf`。此文件包含密钥，因此必须确保其他用户和组没有读/写该文件的权限。下面是我们将添加的内容，用于提供发起方的存储位置：
 
-```json
+```ini
 auth-group ag0 {
     chap-mutual “inituser1” “secretpassw0rd” “targetuser1” “topspassw0rd”
 initiator-portal [2001:db8:1::1]
@@ -79,7 +79,7 @@ target iqn.2012-06.org.example.iscsi:target2 {
 
 我们来分解一下这个文件，理解每个组件的作用及原因：
 
-```json
+```ini
 auth-group ag0 {
     chap-mutual “inituser1” “secretpassw0rd” “targetuser1” “topspassw0rd”
 initiator-portal [2001:db8:1::1]
@@ -91,7 +91,7 @@ initiator-portal [2001:db8:1::1]
 
 这种身份验证可能足够用于发起方和目标方位于同一物理网络的情况，但不应将其作为唯一的安全控制手段。此类身份验证应被视为确保仅分配正确存储给发起方的方法。配置松散的 iSCSI 目标可能会使错误的存储可用，可能会造成数据、分区表或其他元数据被覆盖，因此，限制访问特定目标数据集至关重要。
 
-```json
+```ini
 portal-group pg0        {
     discovery-auth-group no-authentication
     listen [2001:db8:1::a]
@@ -100,7 +100,7 @@ portal-group pg0        {
 
 门户组设置了提供给发起方的目标环境。在这里，我们定义了一个门户组，允许发起方通过 `2001:db8:1::a` 连接到目标方，这样它们可以在无需先进行身份验证的情况下发现包括此门户组的目标数据集。通常在受控环境中，可以这样做，以确保发起方能够找到它们需要连接的目标，但在更加敌对和不受信任的环境中，这种做法则是不理想的。
 
-```json
+```ini
 target iqn.2012-06.org.example.iscsi:target1 {
     alias “Target for FreeBSD”
     auth-group ag0
@@ -136,14 +136,14 @@ service ctld start
 
 为了验证存储是否已出现，你可以检查守护进程是否在监听：
 
-```json
+```sh
 # netstat -na | grep 3260
 tcp6    0      0 2001:db8:1::a.3260     *.*     
 ```
 
 然后，使用 CAM 目标层控制实用程序验证 LUN 是否已出现：
 
-```json
+```sh
 # ctladm lunlist
 (7:1:0/0):<FREEBSD CTLDISK 0001> Fixed Direct Access SPC-5 SCSI device
 (7:1:1/1):<FREEBSD CTLDISK 0001> Fixed Direct Access SPC-5 SCSI device
@@ -155,7 +155,7 @@ LUN Backend     Size (Blocks)   BS Serial Number     Device ID
 
 接下来，配置你的 FreeBSD 发起方。你需要创建配置文件 `/etc/iscsi.conf`。由于此文件包含机密信息，因此也需要显式设置为仅 root 可读写：
 
-```json
+```ini
 fblock0         {
 targetaddress   = [2001:db8:1::a];
 targetname      = iqn.2012-06.org.example.iscsi:target1;

--- a/2024-0910/Enhancing.md
+++ b/2024-0910/Enhancing.md
@@ -86,13 +86,13 @@ Kyua 可以通过配置实现测试用例的并行运行。默认情况下，`pa
 
 目前，Kyua 仅支持一种额外的执行环境——jail 环境。虽然可以为单个测试用例配置该环境，但以下示例展示了如何将 `execenv` 元数据属性应用于测试程序中的所有测试用例：
 
-```json
+```ini
 atf_test_program{name=”test_program”, execenv=”jail”}
 ```
 
 此配置使 Kyua 为 `test_program` 中的每个测试用例提供一个临时的 jail 来执行。如果某个测试用例声明了清理例程，该例程也将在相同的 jail 中执行。Kyua 使用 [`jail(8)`](https://man.freebsd.org/cgi/man.cgi?query=jail&sektion=8) 创建这些 jail，测试用例可以通过一个名为 `execenv_jail_params` 的新元数据属性传递额外的参数：
 
-```json
+```ini
 atf_test_program{name=”test_program”, execenv=”jail”, execenv_jail_params=”vnet allow.raw_sockets”}
 ```
 


### PR DESCRIPTION
## Sourcery 总结

将 iSCSI 配置文档中的 JSON 格式代码块转换为更合适的配置格式（INI 和 shell）

增强功能：
- 将 JSON 语法替换为更适合 iSCSI 配置文件和命令输出的配置格式

文档：
- 更新 iSCSI 配置文档中的代码块格式，以使用正确的语法高亮和配置格式

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Convert JSON-formatted code blocks to more appropriate configuration formats (INI and shell) in an iSCSI configuration documentation

Enhancements:
- Replace JSON syntax with more suitable configuration formats for iSCSI configuration files and command outputs

Documentation:
- Update code block formatting in iSCSI configuration documentation to use correct syntax highlighting and configuration formats

</details>